### PR TITLE
Check if top level project is available before accessing it

### DIFF
--- a/src/main/java/org/hibernate/infra/develocity/scan/BuildScanMetadata.java
+++ b/src/main/java/org/hibernate/infra/develocity/scan/BuildScanMetadata.java
@@ -10,6 +10,7 @@ import java.util.regex.Pattern;
 
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Profile;
+import org.apache.maven.project.MavenProject;
 import org.hibernate.infra.develocity.GoalMetadataProvider;
 import org.hibernate.infra.develocity.Log;
 import org.hibernate.infra.develocity.util.JavaVersions;
@@ -36,7 +37,10 @@ public final class BuildScanMetadata {
 		if ( !isBlank( mavenCommandLine ) ) {
 			buildScanApi.value( "Maven command line", mavenCommandLine );
 		}
-		buildScanApi.tag(mavenSession.getTopLevelProject().getGroupId());
+		MavenProject topLevelProject = mavenSession.getTopLevelProject();
+		if (topLevelProject != null) {
+			buildScanApi.tag(topLevelProject.getGroupId());
+		}
 	}
 
 


### PR DESCRIPTION
otherwise:

```
[ERROR] Error executing a DevelocityListener callback
java.lang.NullPointerException: Cannot invoke "org.apache.maven.project.MavenProject.getGroupId()" because the return value of "org.apache.maven.execution.MavenSession.getTopLevelProject()" is null
    at org.hibernate.infra.develocity.scan.BuildScanMetadata.addMainMetadata (BuildScanMetadata.java:39)
    at org.hibernate.infra.develocity.HibernateMavenBasedProjectDevelocityListener.configure (HibernateMavenBasedProjectDevelocityListener.java:29)
    at com.gradle.maven.internal.DevelocityLifecycleManager.a (SourceFile:400)
    at java.lang.Iterable.forEach (Iterable.java:75)
    at java.util.Collections$UnmodifiableCollection.forEach (Collections.java:1117)
    at com.gradle.maven.internal.DevelocityLifecycleManager.b (SourceFile:398)
    at com.gradle.maven.internal.DevelocityLifecycleManager.c (SourceFile:370)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.accept (ForEachOps.java:184)
    at java.util.stream.ReferencePipeline$15$1.accept (ReferencePipeline.java:581)
    at java.util.stream.IntPipeline$1$1.accept (IntPipeline.java:180)
    at java.util.stream.Streams$RangeIntSpliterator.forEachRemaining (Streams.java:104)
    at java.util.Spliterator$OfInt.forEachRemaining (Spliterator.java:712)
    at java.util.stream.AbstractPipeline.copyInto (AbstractPipeline.java:570)
    at java.util.stream.AbstractPipeline.wrapAndCopyInto (AbstractPipeline.java:560)
    at java.util.stream.ForEachOps$ForEachOp.evaluateSequential (ForEachOps.java:151)
    at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential (ForEachOps.java:174)
    at java.util.stream.AbstractPipeline.evaluate (AbstractPipeline.java:265)
    at java.util.stream.ReferencePipeline.forEach (ReferencePipeline.java:636)
    at com.gradle.maven.internal.DevelocityLifecycleManager.a (SourceFile:370)
    at com.gradle.maven.internal.DevelocityLifecycleManager.onEvent (SourceFile:313)
    at org.apache.maven.eventspy.internal.EventSpyDispatcher.onEvent (EventSpyDispatcher.java:86)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:908)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:283)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:206)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:103)
    at java.lang.reflect.Method.invoke (Method.java:580)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:255)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:201)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:361)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:314)
```
might occur